### PR TITLE
Add new max tokens field

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -184,18 +184,20 @@ type ChatCompletionResponseFormat struct {
 
 // ChatCompletionRequest represents a request structure for chat completion API.
 type ChatCompletionRequest struct {
-	Model            string                        `json:"model"`
-	Messages         []ChatCompletionMessage       `json:"messages"`
-	MaxTokens        int                           `json:"max_tokens,omitempty"`
-	Temperature      float32                       `json:"temperature,omitempty"`
-	TopP             float32                       `json:"top_p,omitempty"`
-	N                int                           `json:"n,omitempty"`
-	Stream           bool                          `json:"stream,omitempty"`
-	Stop             []string                      `json:"stop,omitempty"`
-	PresencePenalty  float32                       `json:"presence_penalty,omitempty"`
-	ResponseFormat   *ChatCompletionResponseFormat `json:"response_format,omitempty"`
-	Seed             *int                          `json:"seed,omitempty"`
-	FrequencyPenalty float32                       `json:"frequency_penalty,omitempty"`
+	Model    string                  `json:"model"`
+	Messages []ChatCompletionMessage `json:"messages"`
+	// Deprecated: use MaxCompletionTokens instead.
+	MaxTokens           int                           `json:"max_tokens,omitempty"`
+	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
+	Temperature         float32                       `json:"temperature,omitempty"`
+	TopP                float32                       `json:"top_p,omitempty"`
+	N                   int                           `json:"n,omitempty"`
+	Stream              bool                          `json:"stream,omitempty"`
+	Stop                []string                      `json:"stop,omitempty"`
+	PresencePenalty     float32                       `json:"presence_penalty,omitempty"`
+	ResponseFormat      *ChatCompletionResponseFormat `json:"response_format,omitempty"`
+	Seed                *int                          `json:"seed,omitempty"`
+	FrequencyPenalty    float32                       `json:"frequency_penalty,omitempty"`
 	// LogitBias is must be a token id string (specified by their token ID in the tokenizer), not a word string.
 	// incorrect: `"logit_bias":{"You": 6}`, correct: `"logit_bias":{"1639": 6}`
 	// refs: https://platform.openai.com/docs/api-reference/chat/create#chat/create-logit_bias


### PR DESCRIPTION
adding `MaxCompletionTokens` to make our chat completions compatible with the o1 models, otherwise we fail with:

```
HTTP 500 Internal Server Error: { "code": "unknown", "message": "error, status code: 400, message: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", "details": null }
```

Also from the [docs](https://platform.openai.com/docs/api-reference/chat/create)
<img width="659" alt="Screenshot 2024-09-16 at 21 06 41" src="https://github.com/user-attachments/assets/af026b3f-ac0b-4629-ab3f-7f0148cf08f8">
