### PR TITLE
Add latest `o1` model

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -12,10 +12,8 @@ var (
 	ErrCompletionRequestPromptTypeNotSupported = errors.New("the type of CompletionRequest.Prompt only supports string and []string")                              //nolint:lll
 )
 
-// GPT3 Defines the models provided by OpenAI to use when generating
+// Defines the models provided by OpenAI to use when generating
 // completions from OpenAI.
-// GPT3 Models are designed for text-based tasks. For code-specific
-// tasks, please refer to the Codex series of models.
 const (
 	GPTO120241217         = "o1-2024-12-17"
 	GPTO1Preview          = "o1-preview"

--- a/completion.go
+++ b/completion.go
@@ -88,6 +88,7 @@ const (
 
 var disabledModelsForEndpoints = map[string]map[string]bool{
 	"/completions": {
+		GPTO120241217:        true,
 		GPTO1Preview:         true,
 		GPTO1Preview20240912: true,
 		GPTO1Mini:            true,

--- a/completion.go
+++ b/completion.go
@@ -17,6 +17,7 @@ var (
 // GPT3 Models are designed for text-based tasks. For code-specific
 // tasks, please refer to the Codex series of models.
 const (
+	GPTO120241217         = "o1-2024-12-17"
 	GPTO1Preview          = "o1-preview"
 	GPTO1Preview20240912  = "o1-preview-2024-09-12"
 	GPTO1Mini             = "o1-mini"


### PR DESCRIPTION
https://platform.openai.com/docs/models#o1

We have early access to the `o1` , so pulling it into our fork (the main go-openai repo doesn't even have it yet)