### PR TITLE
[usage] Add GroqCloud extra fields

### DIFF
--- a/common.go
+++ b/common.go
@@ -4,7 +4,13 @@ package openai
 
 // Usage Represents the total token usage per request to OpenAI.
 type Usage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+
+	// GroqCloud-specific fields (available in GroqCloud response)
+	QueueTime        float64 `json:"queue_time,omitempty"`
+	PromptTime       float64 `json:"prompt_time,omitempty"`
+	CompletionTime   float64 `json:"completion_time,omitempty"`
+	TotalTime        float64 `json:"total_time,omitempty"`
 }


### PR DESCRIPTION
I don't think it's practical to spend time moving Groq out of the OpenAI API just for these fields. They're mostly compatible in other respects.