### PR TITLE
go-openai: add headers to ResponseError

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,6 +38,10 @@ func (h *httpHeader) GetRateLimitHeaders() RateLimitHeaders {
 	return newRateLimitHeaders(h.Header())
 }
 
+func (h *httpHeader) GetRequestID() string {
+	return h.Header().Get("x-request-id")
+}
+
 type RawResponse struct {
 	io.ReadCloser
 
@@ -257,6 +261,7 @@ func (c *Client) handleErrorResp(resp *http.Response) error {
 		reqErr := &RequestError{
 			HTTPStatusCode: resp.StatusCode,
 			Err:            err,
+			httpHeader:     httpHeader(resp.Header),
 		}
 		if errRes.Error != nil {
 			reqErr.Err = errRes.Error

--- a/error.go
+++ b/error.go
@@ -27,6 +27,8 @@ type InnerError struct {
 type RequestError struct {
 	HTTPStatusCode int
 	Err            error
+
+	httpHeader
 }
 
 type ErrorResponse struct {


### PR DESCRIPTION
Attempting to get at the x-request-id when a completion fails