### PR TITLE
Enable anonymous mode in GenerateSchema to hide $id field

### DIFF
--- a/jsonschema/json.go
+++ b/jsonschema/json.go
@@ -55,6 +55,7 @@ func (d Definition) MarshalJSON() ([]byte, error) {
 // It uses github.com/invopop/jsonschema with settings optimized for OpenAI structured outputs:
 //   - AdditionalProperties is always false (strict mode)
 //   - No $ref usage (schemas are fully inlined)
+//   - Anonymous mode enabled (no $id field to avoid leaking package paths)
 //
 // Supported struct tags:
 //   - `json:"field_name"` for the JSON field name
@@ -78,6 +79,7 @@ func GenerateSchema[T any]() *jsonschema.Schema {
 	reflector := jsonschema.Reflector{
 		AllowAdditionalProperties: false,
 		DoNotReference:            true,
+		Anonymous:                 true,
 	}
 	var v T
 	return reflector.Reflect(v)


### PR DESCRIPTION
The $id field was auto-generated from the Go package path and it'd give internal repository structure (e.g., github.com/gradientlabs-ai/agent/skills/plan). Setting Anonymous: true removes this field from generated schemas. It doesn't hugely matter since we have zero data retention with most providers now but less data to give them.