### PR TITLE
[go-openai] Fix temperature omitempty dropping zero value

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -71,7 +71,7 @@ type ChatMessageImageURL struct {
 // And for uploading files: https://platform.openai.com/docs/guides/pdf-files?api-mode=chat&lang=python#uploading-files
 type ChatMessageFileData struct {
 	// Use FileID to reference a file already uploaded to OpenAI via their Files API.
-	FileID   string `json:"file_id,omitempty"`
+	FileID string `json:"file_id,omitempty"`
 	// Otherwise use FileData to pass in the file data as a base64 data URL.
 	FileData string `json:"file_data,omitempty"`
 	// Filename seems to be a required field, even when passing in the file data as bytes.
@@ -205,7 +205,7 @@ type ChatCompletionRequest struct {
 	MaxTokens int `json:"max_tokens,omitempty"`
 	// MaxCompletionTokens should be used for OpenAI provider
 	MaxCompletionTokens int                           `json:"max_completion_tokens,omitempty"`
-	Temperature         float32                       `json:"temperature,omitempty"`
+	Temperature         *float32                      `json:"temperature,omitempty"`
 	TopP                float32                       `json:"top_p,omitempty"`
 	N                   int                           `json:"n,omitempty"`
 	Stream              bool                          `json:"stream,omitempty"`

--- a/completion.go
+++ b/completion.go
@@ -204,7 +204,7 @@ type CompletionRequest struct {
 	Stop            []string `json:"stop,omitempty"`
 	Stream          bool     `json:"stream,omitempty"`
 	Suffix          string   `json:"suffix,omitempty"`
-	Temperature     float32  `json:"temperature,omitempty"`
+	Temperature     *float32 `json:"temperature,omitempty"`
 	TopP            float32  `json:"top_p,omitempty"`
 	User            string   `json:"user,omitempty"`
 	ReasoningEffort string   `json:"reasoning_effort,omitempty"`

--- a/edits.go
+++ b/edits.go
@@ -8,12 +8,12 @@ import (
 
 // EditsRequest represents a request structure for Edits API.
 type EditsRequest struct {
-	Model       *string `json:"model,omitempty"`
-	Input       string  `json:"input,omitempty"`
-	Instruction string  `json:"instruction,omitempty"`
-	N           int     `json:"n,omitempty"`
-	Temperature float32 `json:"temperature,omitempty"`
-	TopP        float32 `json:"top_p,omitempty"`
+	Model       *string  `json:"model,omitempty"`
+	Input       string   `json:"input,omitempty"`
+	Instruction string   `json:"instruction,omitempty"`
+	N           int      `json:"n,omitempty"`
+	Temperature *float32 `json:"temperature,omitempty"`
+	TopP        float32  `json:"top_p,omitempty"`
 }
 
 // EditsChoice represents one of possible edits.


### PR DESCRIPTION
## Summary
- Change `Temperature` field from `float32` to `*float32` in `ChatCompletionRequest`, `CompletionRequest`, and `EditsRequest`
- With `float32` + `omitempty`, Go's JSON serializer silently drops `temperature=0` because 0 is the zero value. This means every call intending `temperature=0` (deterministic output) was actually running at OpenAI's default `temperature=1`
- With `*float32`, `nil` omits the field (don't send temperature), while `&0.0` explicitly sends `temperature: 0`
- `run.go` already uses `*float32` for the same field -- this aligns the other request structs

## Test plan
- All existing tests pass (`go test ./...`)
- Verify with `encoding/json.Marshal`: a request with `Temperature: nil` omits the field, while `Temperature: ptrFloat32(0)` serializes as `"temperature":0`